### PR TITLE
Add basic ontology reasoning

### DIFF
--- a/hercules_sync/synchronization/ontology_synchronizer.py
+++ b/hercules_sync/synchronization/ontology_synchronizer.py
@@ -2,6 +2,9 @@ from typing import List
 
 from hercules_sync.git import GitFile
 from . import BaseSyncAlgorithm, NaiveSyncAlgorithm, SyncOperation
+from ..triplestore import URIElement
+
+import ontospy
 
 class OntologySynchronizer():
     """ Processes information from a GitHub push event.
@@ -32,4 +35,22 @@ class OntologySynchronizer():
             List of operations that need to be executed to synchronize the file
             with the triplestore.
         """
-        return self._algorithm.do_algorithm(file)
+        ops = self._algorithm.do_algorithm(file)
+        self._annotate_triples(ops, file)
+        return ops
+
+    def _annotate_triples(self, ops: List[SyncOperation], file: GitFile):
+        source_model = ontospy.Ontospy(data=file.source_content, rdf_format='ttl')
+        target_model = ontospy.Ontospy(data=file.target_content, rdf_format='ttl')
+        properties = source_model.all_properties + target_model.all_properties
+        properties_uris = list(map(lambda x: str(x.uri), properties))
+        all_urielements = self._extract_uris_from(ops)
+        for urielement in all_urielements:
+            if urielement in properties_uris:
+                urielement.etype = 'property'
+
+
+    def _extract_uris_from(self, ops: List[SyncOperation]):
+        return [el for op in ops
+                for el in op._triple_info
+                if el.is_uri]

--- a/hercules_sync/triplestore/triple_info.py
+++ b/hercules_sync/triplestore/triple_info.py
@@ -47,6 +47,9 @@ class TripleElement(ABC):
             Instance of a wdi datatype that represents this TripeElement.
         """
 
+    def is_uri(self):
+        return False
+
 class URIElement(TripleElement):
     """ TripleElement class that represents URIs from a triple.
 
@@ -98,6 +101,9 @@ class URIElement(TripleElement):
 
     def to_wdi_datatype(self, **kwargs) -> Union[WDItemID, WDProperty]:
         return self.wdi_class(value=self.id, **kwargs)
+
+    def is_uri(self):
+        return True
 
     def __eq__(self, val):
         return self.uri == val
@@ -210,3 +216,6 @@ class TripleInfo():
 
         return self.subject == other.subject and self.predicate == other.predicate \
                and self.object == other.object
+
+    def __iter__(self):
+        return self.content.__iter__()

--- a/hercules_sync/triplestore/wikibase_adapter.py
+++ b/hercules_sync/triplestore/wikibase_adapter.py
@@ -85,13 +85,13 @@ class WikibaseAdapter(TripleStoreManager):
         statement = objct.to_wdi_datatype(prop_nr=predicate.id)
         data = [statement]
         litem = self._local_item_engine(subject.id, data=data, append_value=[predicate.id])
-        litem.write(self._local_login)
+        litem.write(self._local_login, entity_type=subject.etype, property_datatype=subject.wdi_dtype)
 
     def _remove_statement(self, subject: TripleElement, predicate: TripleElement):
         statement_to_remove = wdi_core.WDBaseDataType.delete_statement(predicate.id)
         data = [statement_to_remove]
         litem = self._local_item_engine(subject.id, data=data)
-        litem.write(self._local_login)
+        litem.write(self._local_login, entity_type=subject.etype, property_datatype=subject.wdi_dtype)
 
     def _get_wb_id_of(self, uriref: URIElement, property_datatype='string'):
         wb_uri = get_uri_for(uriref.uri)

--- a/notebooks/.ipynb_checkpoints/GenerateURIs-checkpoint.ipynb
+++ b/notebooks/.ipynb_checkpoints/GenerateURIs-checkpoint.ipynb
@@ -1,0 +1,118 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Generate Wikibase URIs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This notebook generates the wikibase URIs of the resources in a given ontology. It also serves as an example of how an ontology reasoner is used to infer whether an URI corresponds to a wikibase Item or Property."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:root:Starting logger\n"
+     ]
+    }
+   ],
+   "source": [
+    "import logging\n",
+    "import os\n",
+    "import sys\n",
+    "\n",
+    "# set up module paths for imports\n",
+    "module_path = os.path.abspath(os.path.join('..'))\n",
+    "hercules_sync_path = os.path.abspath(os.path.join('..', 'hercules_sync'))\n",
+    "sys.path.append(module_path)\n",
+    "sys.path.append(hercules_sync_path)\n",
+    "\n",
+    "# start logging system and set logging level\n",
+    "logger = logging.getLogger()\n",
+    "logger.setLevel(logging.INFO)\n",
+    "logging.info(\"Starting logger\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Loading the ontology"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ONTOLOGY_LOCATION = 'https://raw.githubusercontent.com/weso/hercules-ontology/master/src/asio-core.ttl'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from urllib.request import urlopen\n",
+    "\n",
+    "onto_content = urlopen(ONTOLOGY_LOCATION).read().decode('utf-8')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from rdflib.graph import Graph\n",
+    "\n",
+    "onto_graph = Graph().parse(format='turtle', data=onto_content)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ontospy\n",
+    "\n",
+    "model = ontospy.Ontospy(data=onto_content, verbose=True)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/notebooks/.ipynb_checkpoints/Synchronization-checkpoint.ipynb
+++ b/notebooks/.ipynb_checkpoints/Synchronization-checkpoint.ipynb
@@ -186,6 +186,8 @@
     "\n",
     "ex:ResearchPersonnel rdf:type owl:Class ;\n",
     "                     rdfs:subClassOf ex:HumanResource .\n",
+    "\n",
+    "ex:authors rdf:type owl:ObjectProperty .\n",
     "\"\"\""
    ]
   },
@@ -204,12 +206,13 @@
     {
      "data": {
       "text/plain": [
-       "[<hercules_sync.synchronization.operations.AdditionOperation at 0x11b10bda0>,\n",
-       " <hercules_sync.synchronization.operations.AdditionOperation at 0x11b10ba58>,\n",
-       " <hercules_sync.synchronization.operations.AdditionOperation at 0x11b12c0b8>,\n",
-       " <hercules_sync.synchronization.operations.AdditionOperation at 0x11b12c1d0>,\n",
-       " <hercules_sync.synchronization.operations.AdditionOperation at 0x11b12c2e8>,\n",
-       " <hercules_sync.synchronization.operations.AdditionOperation at 0x11b12c400>]"
+       "[<hercules_sync.synchronization.operations.AdditionOperation at 0x11f04ec18>,\n",
+       " <hercules_sync.synchronization.operations.AdditionOperation at 0x11f04e9b0>,\n",
+       " <hercules_sync.synchronization.operations.AdditionOperation at 0x11f04ef60>,\n",
+       " <hercules_sync.synchronization.operations.AdditionOperation at 0x11f06d048>,\n",
+       " <hercules_sync.synchronization.operations.AdditionOperation at 0x11f06d160>,\n",
+       " <hercules_sync.synchronization.operations.AdditionOperation at 0x11f06d278>,\n",
+       " <hercules_sync.synchronization.operations.AdditionOperation at 0x11f06d390>]"
       ]
      },
      "execution_count": 7,
@@ -232,7 +235,7 @@
     {
      "data": {
       "text/plain": [
-       "'AdditionOperation: URIElement: http://www.semanticweb.org/spitxa/ontologies/2020/1/asio-human-resource#ResearchPersonnel - Type: item - URIElement: http://www.w3.org/1999/02/22-rdf-syntax-ns#type - Type: item - URIElement: http://www.w3.org/2002/07/owl#Class - Type: item'"
+       "'AdditionOperation: URIElement: http://www.semanticweb.org/spitxa/ontologies/2020/1/asio-human-resource#AdministrativePersonnel - Type: item - URIElement: http://www.w3.org/2000/01/rdf-schema#subClassOf - Type: item - URIElement: http://www.semanticweb.org/spitxa/ontologies/2020/1/asio-human-resource#HumanResource - Type: item'"
       ]
      },
      "execution_count": 8,
@@ -241,7 +244,7 @@
     }
    ],
    "source": [
-    "str(ops[4])"
+    "str(ops[-1])"
    ]
   },
   {
@@ -263,11 +266,11 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/Users/alejandro/anaconda3/envs/weso/lib/python3.7/site-packages/wikidataintegrator/wdi_core.py:218: UserWarning: Warning: No distinct value properties found\n",
+      "/Users/laika/Documents/envs/herc_sync/lib/python3.6/site-packages/wikidataintegrator/wdi_core.py:219: UserWarning: Warning: No distinct value properties found\n",
       "Please set P2302 and Q21502410 in your wikibase or set `core_props` manually.\n",
       "Continuing with no core_props\n",
-      "  \"Please set P2302 and Q21502410 in your wikibase or set `core_props` manually.\\n\" +\n",
-      "/Users/alejandro/anaconda3/envs/weso/lib/python3.7/site-packages/wikidataintegrator/wdi_core.py:175: UserWarning: mapping relation types are being ignored\n",
+      "  \"Continuing with no core_props\")\n",
+      "/Users/laika/Documents/envs/herc_sync/lib/python3.6/site-packages/wikidataintegrator/wdi_core.py:175: UserWarning: mapping relation types are being ignored\n",
       "  warnings.warn(\"mapping relation types are being ignored\")\n"
      ]
     }
@@ -302,12 +305,14 @@
     "* Add a new entity (ChangedPersonnel) of type owl:Class.\n",
     "* Add labels and description to the ResearchPersonnel entity.\n",
     "* Change the subclassOf property of ResearchPersonnel from HumanResource to ChangedPersonnel (for illustrative purposes).\n",
-    "* Change the disjointWith property of AdministrativePersonnel from ResearchPersonnel to ChangedPersonnel."
+    "* Change the disjointWith property of AdministrativePersonnel from ResearchPersonnel to ChangedPersonnel.\n",
+    "* Create a new 'authoredBy' property.\n",
+    "* Set 'authors' as a subProperty of 'authoredBy'."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -344,12 +349,16 @@
     "                                   \"Pessoal técnico\"@pt ,\n",
     "                                   \"Technical personnel\"@en .\n",
     "\n",
+    "ex:authoredBy rdf:type owl:ObjectProperty .\n",
+    "\n",
+    "ex:authors rdf:type owl:ObjectProperty ;\n",
+    "           rdfs:subPropertyOf ex:authoredBy .\n",
     "\"\"\""
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -370,12 +379,13 @@
     "Finally, we are going to remove some statements from our entities:\n",
     "* Remove type statement from the ChangedPersonnel entity.\n",
     "* Remove subclassOf statement from the ResearchPersonnel entity.\n",
-    "* Remove label @pt from ResearchPersonnel."
+    "* Remove label @pt from ResearchPersonnel.\n",
+    "* Delete authors and authoredBy content."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -411,7 +421,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -449,7 +459,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.6.5"
   }
  },
  "nbformat": 4,

--- a/notebooks/GenerateURIs.ipynb
+++ b/notebooks/GenerateURIs.ipynb
@@ -1,0 +1,357 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Generate Wikibase URIs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This notebook generates the wikibase URIs of the resources in a given ontology. It also serves as an example of how an ontology reasoner is used to infer whether an URI corresponds to a wikibase Item or Property."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:root:Starting logger\n"
+     ]
+    }
+   ],
+   "source": [
+    "import logging\n",
+    "import os\n",
+    "import sys\n",
+    "\n",
+    "# set up module paths for imports\n",
+    "module_path = os.path.abspath(os.path.join('..'))\n",
+    "hercules_sync_path = os.path.abspath(os.path.join('..', 'hercules_sync'))\n",
+    "sys.path.append(module_path)\n",
+    "sys.path.append(hercules_sync_path)\n",
+    "\n",
+    "# start logging system and set logging level\n",
+    "logger = logging.getLogger()\n",
+    "logger.setLevel(logging.INFO)\n",
+    "logging.info(\"Starting logger\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Loading the ontology"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ONTOLOGY_LOCATION = 'https://raw.githubusercontent.com/weso/hercules-ontology/master/src/asio-core.ttl'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from urllib.request import urlopen\n",
+    "\n",
+    "onto_content = urlopen(ONTOLOGY_LOCATION).read().decode('utf-8')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from rdflib.graph import Graph\n",
+    "\n",
+    "onto_graph = Graph().parse(format='turtle', data=onto_content)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Obtaining the classes and properties"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "----------\n",
+      "Reading: '@prefix :  ...'\n",
+      ".. trying rdf serialization: <ttl>\n",
+      "..... success!\n",
+      "----------\n",
+      "Loaded 1337 triples.\n",
+      "----------\n",
+      "RDF sources loaded successfully: 1 of 1.\n",
+      "..... 'Data: '@prefix :  ...''\n",
+      "----------\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Scanning entities...\n",
+      "----------\n",
+      "Ontologies.........: 1\n",
+      "Classes............: 71\n",
+      "Properties.........: 48\n",
+      "..annotation.......: 3\n",
+      "..datatype.........: 6\n",
+      "..object...........: 39\n",
+      "Concepts (SKOS)....: 0\n",
+      "Shapes (SHACL).....: 0\n",
+      "----------\n"
+     ]
+    }
+   ],
+   "source": [
+    "import ontospy\n",
+    "\n",
+    "model = ontospy.Ontospy(data=onto_content, verbose=True, rdf_format='ttl')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[<Class *http://www.asio.es/asioontologies/asio#AcademicDegree*>,\n",
+       " <Class *http://www.asio.es/asioontologies/asio#AcademicPublication*>,\n",
+       " <Class *http://www.asio.es/asioontologies/asio#AdministrativeEntity*>,\n",
+       " <Class *http://www.asio.es/asioontologies/asio#AdministrativePersonnel*>,\n",
+       " <Class *http://www.asio.es/asioontologies/asio#Article*>]"
+      ]
+     },
+     "execution_count": 36,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "model.all_classes[:5]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 81,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[<Class *http://www.w3.org/2001/XMLSchema#boolean*>]"
+      ]
+     },
+     "execution_count": 81,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "model.all_properties[19].ranges"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 65,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "list"
+      ]
+     },
+     "execution_count": 65,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "type(model.all_properties)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 62,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "uri_items = map(lambda x: x.uri, model.all_classes)\n",
+    "uri_props = map(lambda x: x.uri, model.all_properties)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 63,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "triple = None\n",
+    "for el in onto_graph:\n",
+    "    triple = el"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 64,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 64,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "triple[0] in uri_props"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 52,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "rdflib.term.URIRef('http://www.asio.es/asioontologies/asio#funds')"
+      ]
+     },
+     "execution_count": 52,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "triple[0]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Creating ids for each item and property"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class WBIdGeneratorMock():\n",
+    "    def __init__(self):\n",
+    "        self.q_id = 0\n",
+    "        self.p_id = 0\n",
+    "    \n",
+    "    def generate_item_id(self):\n",
+    "        self.q_id += 1\n",
+    "        return f\"Q{self.q_id}\"\n",
+    "    \n",
+    "    def generate_prop_id(self):\n",
+    "        self.p_id += 1\n",
+    "        return f\"P{self.p_id}\"\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from hercules_sync.external.uri_factory_mock import URIFactory\n",
+    "\n",
+    "factory = URIFactory()\n",
+    "factory.reset_factory()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "id_generator = WBIdGeneratorMock()\n",
+    "\n",
+    "for item in uri_items:\n",
+    "    item_id = uri_generator.generate_item_id()\n",
+    "    factory.post_uri(item, new_id)\n",
+    "\n",
+    "for item in uri_props:\n",
+    "    prop_id = uri_generator.generate_prop_id()\n",
+    "    factory.post_uri(item, prop_id)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Save the mappings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "all_uris = uri_items + uri_props\n",
+    "\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/notebooks/Synchronization.ipynb
+++ b/notebooks/Synchronization.ipynb
@@ -186,6 +186,8 @@
     "\n",
     "ex:ResearchPersonnel rdf:type owl:Class ;\n",
     "                     rdfs:subClassOf ex:HumanResource .\n",
+    "\n",
+    "ex:authors rdf:type owl:ObjectProperty .\n",
     "\"\"\""
    ]
   },
@@ -204,12 +206,13 @@
     {
      "data": {
       "text/plain": [
-       "[<hercules_sync.synchronization.operations.AdditionOperation at 0x112c0cc50>,\n",
-       " <hercules_sync.synchronization.operations.AdditionOperation at 0x112c0c908>,\n",
-       " <hercules_sync.synchronization.operations.AdditionOperation at 0x112c0cf60>,\n",
-       " <hercules_sync.synchronization.operations.AdditionOperation at 0x112c2e080>,\n",
-       " <hercules_sync.synchronization.operations.AdditionOperation at 0x112c2e198>,\n",
-       " <hercules_sync.synchronization.operations.AdditionOperation at 0x112c2e2b0>]"
+       "[<hercules_sync.synchronization.operations.AdditionOperation at 0x11f04ec18>,\n",
+       " <hercules_sync.synchronization.operations.AdditionOperation at 0x11f04e9b0>,\n",
+       " <hercules_sync.synchronization.operations.AdditionOperation at 0x11f04ef60>,\n",
+       " <hercules_sync.synchronization.operations.AdditionOperation at 0x11f06d048>,\n",
+       " <hercules_sync.synchronization.operations.AdditionOperation at 0x11f06d160>,\n",
+       " <hercules_sync.synchronization.operations.AdditionOperation at 0x11f06d278>,\n",
+       " <hercules_sync.synchronization.operations.AdditionOperation at 0x11f06d390>]"
       ]
      },
      "execution_count": 7,
@@ -232,7 +235,7 @@
     {
      "data": {
       "text/plain": [
-       "'AdditionOperation: URIElement: http://www.semanticweb.org/spitxa/ontologies/2020/1/asio-human-resource#AdministrativePersonnel - Type: item - URIElement: http://www.w3.org/2002/07/owl#disjointWith - Type: item - URIElement: http://www.semanticweb.org/spitxa/ontologies/2020/1/asio-human-resource#ResearchPersonnel - Type: item'"
+       "'AdditionOperation: URIElement: http://www.semanticweb.org/spitxa/ontologies/2020/1/asio-human-resource#AdministrativePersonnel - Type: item - URIElement: http://www.w3.org/2000/01/rdf-schema#subClassOf - Type: item - URIElement: http://www.semanticweb.org/spitxa/ontologies/2020/1/asio-human-resource#HumanResource - Type: item'"
       ]
      },
      "execution_count": 8,
@@ -241,7 +244,7 @@
     }
    ],
    "source": [
-    "str(ops[4])"
+    "str(ops[-1])"
    ]
   },
   {
@@ -263,11 +266,11 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/Users/alejandro/anaconda3/envs/weso/lib/python3.7/site-packages/wikidataintegrator/wdi_core.py:218: UserWarning: Warning: No distinct value properties found\n",
+      "/Users/laika/Documents/envs/herc_sync/lib/python3.6/site-packages/wikidataintegrator/wdi_core.py:219: UserWarning: Warning: No distinct value properties found\n",
       "Please set P2302 and Q21502410 in your wikibase or set `core_props` manually.\n",
       "Continuing with no core_props\n",
-      "  \"Please set P2302 and Q21502410 in your wikibase or set `core_props` manually.\\n\" +\n",
-      "/Users/alejandro/anaconda3/envs/weso/lib/python3.7/site-packages/wikidataintegrator/wdi_core.py:175: UserWarning: mapping relation types are being ignored\n",
+      "  \"Continuing with no core_props\")\n",
+      "/Users/laika/Documents/envs/herc_sync/lib/python3.6/site-packages/wikidataintegrator/wdi_core.py:175: UserWarning: mapping relation types are being ignored\n",
       "  warnings.warn(\"mapping relation types are being ignored\")\n"
      ]
     }
@@ -302,7 +305,9 @@
     "* Add a new entity (ChangedPersonnel) of type owl:Class.\n",
     "* Add labels and description to the ResearchPersonnel entity.\n",
     "* Change the subclassOf property of ResearchPersonnel from HumanResource to ChangedPersonnel (for illustrative purposes).\n",
-    "* Change the disjointWith property of AdministrativePersonnel from ResearchPersonnel to ChangedPersonnel."
+    "* Change the disjointWith property of AdministrativePersonnel from ResearchPersonnel to ChangedPersonnel.\n",
+    "* Create a new 'authoredBy' property.\n",
+    "* Set 'authors' as a subProperty of 'authoredBy'."
    ]
   },
   {
@@ -344,6 +349,10 @@
     "                                   \"Pessoal técnico\"@pt ,\n",
     "                                   \"Technical personnel\"@en .\n",
     "\n",
+    "ex:authoredBy rdf:type owl:ObjectProperty .\n",
+    "\n",
+    "ex:authors rdf:type owl:ObjectProperty ;\n",
+    "           rdfs:subPropertyOf ex:authoredBy .\n",
     "\"\"\""
    ]
   },
@@ -370,12 +379,13 @@
     "Finally, we are going to remove some statements from our entities:\n",
     "* Remove type statement from the ChangedPersonnel entity.\n",
     "* Remove subclassOf statement from the ResearchPersonnel entity.\n",
-    "* Remove label @pt from ResearchPersonnel."
+    "* Remove label @pt from ResearchPersonnel.\n",
+    "* Delete authors and authoredBy content."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -411,7 +421,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -449,7 +459,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.6.5"
   }
  },
  "nbformat": 4,

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ sphinx-markdown-tables==0.0.12
 stsci-rtd-theme==0.0.2
 tqdm==4.42.1
 typed-ast==1.4.1
+ontospy==1.9.8.3
 unidiff==0.5.5
 urllib3==1.25.8
 Werkzeug==0.16.1

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,0 +1,12 @@
+import os
+
+from hercules_sync.git import GitFile
+
+DATA_DIR = os.path.join(os.path.dirname(__file__), 'data', 'synchronization')
+
+def load_gitfile_from(source, target):
+    with open(os.path.join(DATA_DIR, source), 'r') as f:
+        source_content = f.read()
+    with open(os.path.join(DATA_DIR, target), 'r') as f:
+        target_content = f.read()
+    return GitFile(None, source_content, target_content)

--- a/tests/data/synchronization/source_props.ttl
+++ b/tests/data/synchronization/source_props.ttl
@@ -1,0 +1,10 @@
+#################################################################
+# Example ontology.                                             #
+# This file is used to test the CI and synchronization systems. #
+#################################################################
+
+@prefix ex: <http://www.semanticweb.org/spitxa/ontologies/2020/1/asio-human-resource#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+
+ex:authors rdf:type owl:ObjectProperty .

--- a/tests/data/synchronization/target_props.ttl
+++ b/tests/data/synchronization/target_props.ttl
@@ -1,0 +1,14 @@
+#################################################################
+# Example ontology.                                             #
+# This file is used to test the CI and synchronization systems. #
+#################################################################
+
+@prefix ex: <http://www.semanticweb.org/spitxa/ontologies/2020/1/asio-human-resource#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+ex:authoredBy rdf:type owl:ObjectProperty .
+
+ex:authors rdf:type owl:ObjectProperty ;
+           rdfs:subPropertyOf ex:authoredBy .

--- a/tests/test_algorithms.py
+++ b/tests/test_algorithms.py
@@ -12,7 +12,8 @@ from hercules_sync.triplestore import LiteralElement, URIElement
 from hercules_sync.util.uri_constants import RDFS_COMMENT, RDFS_LABEL, RDFS_SUBCLASSOF, \
                                              RDF_TYPE, OWL_CLASS, OWL_DISJOINT_WITH
 
-DATA_DIR = os.path.join(os.path.dirname(__file__), 'data', 'synchronization')
+from .common import load_gitfile_from
+
 SOURCE_FILE = 'source.ttl'
 TARGET_FILE = 'target.ttl'
 
@@ -21,11 +22,7 @@ EX_PREFIX = 'http://www.semanticweb.org/spitxa/ontologies/2020/1/asio-human-reso
 
 @pytest.fixture(scope='module')
 def input():
-    with open(os.path.join(DATA_DIR, SOURCE_FILE), 'r') as f:
-        source_content = f.read()
-    with open(os.path.join(DATA_DIR, TARGET_FILE), 'r') as f:
-        target_content = f.read()
-    return GitFile(None, source_content, target_content)
+    return load_gitfile_from(SOURCE_FILE, TARGET_FILE)
 
 class TestNaiveSyncAlgorithm:
     @pytest.fixture(scope='class')

--- a/tests/test_ontology_synchronizer.py
+++ b/tests/test_ontology_synchronizer.py
@@ -5,12 +5,30 @@ from unittest import mock
 from hercules_sync.synchronization import OntologySynchronizer, GraphDiffSyncAlgorithm, \
                                           NaiveSyncAlgorithm
 
+from .common import load_gitfile_from
+
+SOURCE_FILE = 'source_props.ttl'
+TARGET_FILE = 'target_props.ttl'
+
+ASIO_PREFIX = 'http://www.asio.es/asioontologies/asio#'
+EX_PREFIX = 'http://www.semanticweb.org/spitxa/ontologies/2020/1/asio-human-resource#'
+
 @pytest.fixture(scope='module')
+def input():
+    return load_gitfile_from(SOURCE_FILE, TARGET_FILE)
+
+@pytest.fixture
 def mock_synchronizer():
     with mock.patch.object(OntologySynchronizer, '__init__', lambda slf, algorithm: None):
         synchronizer = OntologySynchronizer(None)
         synchronizer._algorithm = mock.MagicMock()
+        synchronizer._annotate_triples = mock.MagicMock()
         yield synchronizer
+
+@pytest.fixture
+def operations_fixture(input):
+    algorithm = GraphDiffSyncAlgorithm()
+    return algorithm.do_algorithm(input)
 
 def test_init():
     synchronizer = OntologySynchronizer(None)
@@ -22,3 +40,24 @@ def test_init():
 def test_synchronize(mock_synchronizer):
     mock_synchronizer.synchronize(None)
     mock_synchronizer._algorithm.do_algorithm.assert_has_calls([mock.call(None)])
+
+def test_etype_annotation(input):
+    algorithm = GraphDiffSyncAlgorithm()
+    ops = algorithm.do_algorithm(input)
+    # check that original operations have default annotations
+    for op in ops:
+        for element in op._triple_info:
+            if element.is_uri:
+                assert element.etype == 'item'
+
+    synchronizer = OntologySynchronizer(algorithm)
+    annotated_ops = synchronizer._annotate_triples(ops, input)
+    # check that now the subjects of this ontology are classified as properties
+    for op in ops:
+        triple_info = op._triple_info
+        assert triple_info.subject.etype == 'property'
+
+def test_synchronize_annotates_triples(mock_synchronizer):
+    mock_synchronizer.synchronize(None)
+    ops = mock_synchronizer._algorithm.do_algorithm(None)
+    mock_synchronizer._annotate_triples.assert_has_calls([mock.call(ops, None)])

--- a/tests/test_triple_info.py
+++ b/tests/test_triple_info.py
@@ -48,6 +48,10 @@ def test_from_rdflib(rdflib_triple):
     assert triple[2].datatype is None
     assert triple[2].lang is None
 
+def test_is_uri(string_literal, item_uri):
+    assert not string_literal.is_uri()
+    assert item_uri.is_uri()
+
 def test_literal_init():
     lit_a = LiteralElement("hello")
     assert lit_a.content == "hello"

--- a/tests/test_wikibase_adapter.py
+++ b/tests/test_wikibase_adapter.py
@@ -125,7 +125,7 @@ def test_create_triple(mocked_adapter, triples):
         mock.call(login, entity_type='item', property_datatype='string'),
         mock.call(login, entity_type='item', property_datatype='string'),
         mock.call(login, entity_type='property', property_datatype='wikibase-item'),
-        mock.call(login)
+        mock.call(login, entity_type='item', property_datatype='wikibase-item')
     ]
     writer.write.assert_has_calls(write_calls, any_order=False)
 
@@ -192,7 +192,7 @@ def test_remove_triple(mocked_adapter, triples):
     write_calls = [
         mock.call(login, entity_type='item', property_datatype='string'),
         mock.call(login, entity_type='property', property_datatype='wikibase-item'),
-        mock.call(login)
+        mock.call(login, entity_type='item', property_datatype='wikibase-item')
     ]
     writer.write.assert_has_calls(write_calls, any_order=False)
 


### PR DESCRIPTION
We are now now parsing the classes and properties of the ontology, and annotating the type of each URIElement. So now following this example: 
```ttl
ex:authors rdf:type owl:ObjectProperty ;
           rdfs:subPropertyOf ex:authoredBy .
```

It will be inferred that `ex:authors` is a property, and it will be created in Wikibase likewise.

Finally, we can also infer now the datatype of a property, which will considerably ease the implementation of issue #15 

This closes #14  