### PR TITLE
Add batch operations

### DIFF
--- a/hercules_sync/synchronization/__init__.py
+++ b/hercules_sync/synchronization/__init__.py
@@ -1,4 +1,5 @@
-from .operations import AdditionOperation, RemovalOperation, SyncOperation
+from .operations import AdditionOperation, BasicSyncOperation, BatchOperation, \
+                        RemovalOperation, SyncOperation
 from .algorithms import BaseSyncAlgorithm, GraphDiffSyncAlgorithm, \
                         NaiveSyncAlgorithm, RDFSyncAlgorithm
 from .ontology_synchronizer import OntologySynchronizer
@@ -6,6 +7,8 @@ from .ontology_synchronizer import OntologySynchronizer
 __all__ = [
     'AdditionOperation',
     'BaseSyncAlgorithm',
+    'BasicSyncOperation',
+    'BatchOperation',
     'GraphDiffSyncAlgorithm',
     'NaiveSyncAlgorithm',
     'OntologySynchronizer',

--- a/hercules_sync/synchronization/algorithms.py
+++ b/hercules_sync/synchronization/algorithms.py
@@ -9,6 +9,7 @@ from hercules_sync.git import GitFile
 from hercules_sync.triplestore import TripleInfo
 from . import AdditionOperation, RemovalOperation, SyncOperation
 
+
 class BaseSyncAlgorithm(ABC):
     """ Base class for all synchronization algorithms.
     """
@@ -29,9 +30,11 @@ class BaseSyncAlgorithm(ABC):
             with the triplestore.
         """
 
+
 class NaiveSyncAlgorithm(BaseSyncAlgorithm):
     def do_algorithm(self, file: GitFile) -> List[SyncOperation]:
         raise NotImplementedError("NaiveSync algorithm has not been implemented yet.")
+
 
 class GraphDiffSyncAlgorithm(BaseSyncAlgorithm):
     """ Implementation of the Graph diff algorithm to synchronize ontology sources.
@@ -55,6 +58,7 @@ class GraphDiffSyncAlgorithm(BaseSyncAlgorithm):
     def _create_remove_ops_from(self, graph: Graph) -> List[RemovalOperation]:
         return [RemovalOperation(*TripleInfo.from_rdflib(triple).content)
                 for triple in graph]
+
 
 class RDFSyncAlgorithm(BaseSyncAlgorithm):
     """ Implementation of the RDFSync algorithm to synchronize ontology sources.

--- a/hercules_sync/synchronization/operations.py
+++ b/hercules_sync/synchronization/operations.py
@@ -1,7 +1,10 @@
 from abc import ABC, abstractmethod
 from collections import defaultdict
+from typing import List
 
-from ..triplestore import ModificationResult, TripleStoreManager, TripleElement, TripleInfo
+from ..triplestore import ModificationResult, TripleStoreManager, \
+                          TripleElement, TripleInfo
+
 
 class SyncOperation(ABC):
     @abstractmethod
@@ -19,6 +22,7 @@ class SyncOperation(ABC):
             Result given by the TripleStoreManager after the modification.
 
         """
+
 
 class BasicSyncOperation(SyncOperation):
     """ Base class of all the basic synchronization operations.
@@ -52,6 +56,7 @@ class AdditionOperation(BasicSyncOperation):
 
         return self._triple_info == other._triple_info
 
+
 class RemovalOperation(BasicSyncOperation):
     def execute(self, triple_store: TripleStoreManager) -> ModificationResult:
         return triple_store.remove_triple(self._triple_info)
@@ -65,11 +70,12 @@ class RemovalOperation(BasicSyncOperation):
 
         return self._triple_info == other._triple_info
 
+
 class BatchOperation(SyncOperation):
     """
     """
 
-    def __init__(subject: TripleElement, triples: List[TripleInfo]):
+    def __init__(self, subject: TripleElement, triples: List[TripleInfo]):
         self.subject = subject
         self.triples = triples
 
@@ -78,10 +84,11 @@ class BatchOperation(SyncOperation):
 
     def __str__(self):
         res = [f"BatchOperation: {self.subject}"]
-        for triple in triples:
+        for triple in self.triples:
             res.append('\n')
             res.append(str(triple))
         return ''.join(res)
+
 
 def optimize_ops(ops: List[BasicSyncOperation]):
     """
@@ -89,7 +96,7 @@ def optimize_ops(ops: List[BasicSyncOperation]):
     subject_to_triples = defaultdict(list)
     for op in ops:
         triple_info = op._triple_info
-        res_ops[triple_info.subject].append(triple_info)
+        subject_to_triples[triple_info.subject].append(triple_info)
 
     return [BatchOperation(subject, triples)
             for subject, triples in subject_to_triples.items()]

--- a/hercules_sync/synchronization/operations.py
+++ b/hercules_sync/synchronization/operations.py
@@ -37,13 +37,17 @@ class BasicSyncOperation(SyncOperation):
         Object of the triple to be synchronized.
     """
     def __init__(self, sub: TripleElement, pred: TripleElement, obj: TripleElement):
-        self._triple_info = TripleInfo(sub, pred, obj)
+        pass
 
     def __str__(self):
         return f"{self._triple_info.subject} - {self._triple_info.predicate} " \
                + f"- {self._triple_info.object}"
 
+
 class AdditionOperation(BasicSyncOperation):
+    def __init__(self, sub: TripleElement, pred: TripleElement, obj: TripleElement):
+        self._triple_info = TripleInfo(sub, pred, obj, isAdded=True)
+
     def execute(self, triple_store: TripleStoreManager) -> ModificationResult:
         return triple_store.create_triple(self._triple_info)
 
@@ -58,6 +62,9 @@ class AdditionOperation(BasicSyncOperation):
 
 
 class RemovalOperation(BasicSyncOperation):
+    def __init__(self, sub: TripleElement, pred: TripleElement, obj: TripleElement):
+        self._triple_info = TripleInfo(sub, pred, obj, isAdded=False)
+
     def execute(self, triple_store: TripleStoreManager) -> ModificationResult:
         return triple_store.remove_triple(self._triple_info)
 
@@ -72,7 +79,14 @@ class RemovalOperation(BasicSyncOperation):
 
 
 class BatchOperation(SyncOperation):
-    """
+    """ Synchronization operation that performs a batch update on the triplestore
+
+    Parameters
+    ----------
+    sub : TripleElement
+        Common subject of the triples that will be updated.
+    triples : list of TripleInfo
+        List of triples to be updated at once with the batch update.
     """
 
     def __init__(self, subject: TripleElement, triples: List[TripleInfo]):
@@ -90,8 +104,18 @@ class BatchOperation(SyncOperation):
         return ''.join(res)
 
 
-def optimize_ops(ops: List[BasicSyncOperation]):
-    """
+def optimize_ops(ops: List[BasicSyncOperation]) -> List[BatchOperation]:
+    """ Convert a list of basic operations into a list of batch operations.
+
+    Parameters
+    ----------
+    ops: list of BasicSyncOperation
+        Input basic operations to be converted.
+
+    Returns
+    -------
+    list of BatchOperations
+        Final list of batch operations to be executed.
     """
     subject_to_triples = defaultdict(list)
     for op in ops:

--- a/hercules_sync/synchronization/operations.py
+++ b/hercules_sync/synchronization/operations.py
@@ -1,22 +1,9 @@
 from abc import ABC, abstractmethod
+from collections import defaultdict
 
 from ..triplestore import ModificationResult, TripleStoreManager, TripleElement, TripleInfo
 
 class SyncOperation(ABC):
-    """ Base class of all synchronization operations.
-
-    Parameters
-    ----------
-    sub : TripleElement
-        Subject of the triple to be synchronized.
-    pred : TripleElement
-        Predicate of the triple to be synchronized.
-    obj : TripleElement
-        Object of the triple to be synchronized.
-    """
-    def __init__(self, sub: TripleElement, pred: TripleElement, obj: TripleElement):
-        self._triple_info = TripleInfo(sub, pred, obj)
-
     @abstractmethod
     def execute(self, triple_store: TripleStoreManager) -> ModificationResult:
         """ Executes the operation in the given triple store.
@@ -33,11 +20,26 @@ class SyncOperation(ABC):
 
         """
 
+class BasicSyncOperation(SyncOperation):
+    """ Base class of all the basic synchronization operations.
+
+    Parameters
+    ----------
+    sub : TripleElement
+        Subject of the triple to be synchronized.
+    pred : TripleElement
+        Predicate of the triple to be synchronized.
+    obj : TripleElement
+        Object of the triple to be synchronized.
+    """
+    def __init__(self, sub: TripleElement, pred: TripleElement, obj: TripleElement):
+        self._triple_info = TripleInfo(sub, pred, obj)
+
     def __str__(self):
         return f"{self._triple_info.subject} - {self._triple_info.predicate} " \
                + f"- {self._triple_info.object}"
 
-class AdditionOperation(SyncOperation):
+class AdditionOperation(BasicSyncOperation):
     def execute(self, triple_store: TripleStoreManager) -> ModificationResult:
         return triple_store.create_triple(self._triple_info)
 
@@ -50,7 +52,7 @@ class AdditionOperation(SyncOperation):
 
         return self._triple_info == other._triple_info
 
-class RemovalOperation(SyncOperation):
+class RemovalOperation(BasicSyncOperation):
     def execute(self, triple_store: TripleStoreManager) -> ModificationResult:
         return triple_store.remove_triple(self._triple_info)
 
@@ -62,3 +64,32 @@ class RemovalOperation(SyncOperation):
             return False
 
         return self._triple_info == other._triple_info
+
+class BatchOperation(SyncOperation):
+    """
+    """
+
+    def __init__(subject: TripleElement, triples: List[TripleInfo]):
+        self.subject = subject
+        self.triples = triples
+
+    def execute(self, triple_store: TripleStoreManager) -> ModificationResult:
+        return triple_store.batch_update(self.subject, self.triples)
+
+    def __str__(self):
+        res = [f"BatchOperation: {self.subject}"]
+        for triple in triples:
+            res.append('\n')
+            res.append(str(triple))
+        return ''.join(res)
+
+def optimize_ops(ops: List[BasicSyncOperation]):
+    """
+    """
+    subject_to_triples = defaultdict(list)
+    for op in ops:
+        triple_info = op._triple_info
+        res_ops[triple_info.subject].append(triple_info)
+
+    return [BatchOperation(subject, triples)
+            for subject, triples in subject_to_triples.items()]

--- a/hercules_sync/triplestore/triple_info.py
+++ b/hercules_sync/triplestore/triple_info.py
@@ -114,6 +114,7 @@ class AnonymousElement(TripleElement):
     def __str__(self):
         return f"AnonymousElement: {self.uri}"
 
+
 class URIElement(TripleElement):
     """ TripleElement class that represents URIs from a triple.
 

--- a/hercules_sync/triplestore/triple_info.py
+++ b/hercules_sync/triplestore/triple_info.py
@@ -266,6 +266,7 @@ class LiteralElement(TripleElement):
             res.append(f" - DataType: {self.datatype}")
         return ''.join(res)
 
+
 class TripleInfo():
     """ Encapsulate the elements of a semantic triple.
 
@@ -279,17 +280,19 @@ class TripleInfo():
         Object of the triple.
     """
 
-    def __init__(self, sub: TripleElement, pred: TripleElement, obj: TripleElement):
+    def __init__(self, sub: TripleElement, pred: TripleElement, obj: TripleElement,
+                 isAdded=True):
         self.subject = sub
         self.predicate = pred
         self.object = obj
+        self.isAdded = isAdded
 
     @classmethod
-    def from_rdflib(cls, rdflib_triple):
+    def from_rdflib(cls, rdflib_triple, isAdded=True):
         subject = TripleElement.from_rdflib(rdflib_triple[0])
         predicate = TripleElement.from_rdflib(rdflib_triple[1])
         objct = TripleElement.from_rdflib(rdflib_triple[2])
-        return TripleInfo(subject, predicate, objct)
+        return TripleInfo(subject, predicate, objct, isAdded)
 
     @property
     def content(self):
@@ -307,7 +310,7 @@ class TripleInfo():
             return False
 
         return self.subject == other.subject and self.predicate == other.predicate \
-               and self.object == other.object
+            and self.object == other.object
 
     def __iter__(self):
         return self.content.__iter__()

--- a/hercules_sync/triplestore/triple_info.py
+++ b/hercules_sync/triplestore/triple_info.py
@@ -191,11 +191,15 @@ class URIElement(TripleElement):
     def __eq__(self, val):
         return self.uri == val
 
+    def __hash__(self):
+        return hash(self.uri)
+
     def __iter__(self):
         return self.uri.__iter__()
 
     def __str__(self):
         return f"URIElement: {self.uri} - Type: {self.etype}"
+
 
 class LiteralElement(TripleElement):
     """ TripleElement class that represents a literal from a triple.

--- a/hercules_sync/triplestore/wikibase_adapter.py
+++ b/hercules_sync/triplestore/wikibase_adapter.py
@@ -22,6 +22,7 @@ MAPPINGS_PROP_LABEL = "same as"
 MAPPINGS_PROP_DESC = "Mapping of an item to its original URI"
 MAX_CHARACTERS_DESC = 250
 
+
 class WikibaseAdapter(TripleStoreManager):
     """ Adapter to execute operations on a wikibase instance.
 
@@ -42,11 +43,41 @@ class WikibaseAdapter(TripleStoreManager):
 
     def __init__(self, mediawiki_api_url, sparql_endpoint_url, username, password):
         self.api_url = mediawiki_api_url
-        self.sparql_url =  sparql_endpoint_url
+        self.sparql_url = sparql_endpoint_url
         self._local_item_engine = wdi_core.WDItemEngine. \
             wikibase_item_engine_factory(mediawiki_api_url, sparql_endpoint_url)
         self._local_login = wdi_login.WDLogin(username, password, mediawiki_api_url)
         self._mappings_prop = self._get_or_create_mappings_prop()
+        self._create_callbacks = dict('onAlias'=self._set_alias, 'onDesc'=self._set_description,
+                                      'onLabel'=self._set_label, 'onStatement'=self._create_statement)
+        self._remove_callbacks = dict('onAlias'=self._remove_alias, 'onDesc'=self._remove_description,
+                                      'onLabel'=self._remove_label, 'onStatement'=self._renmove_statement)
+
+    def batch_update(self, subject: TripleElement, triples: List[TripleInfo]) -> ModificationResult:
+        """ Update a set of triples with a given subject in a single transaction
+
+        Parameters
+        ----------
+        subject: :obj:`TripleElement`
+            Common subject of all the triples that will be updated.
+
+        triples: list of :obj:`TripleElement`
+            List of triples to update.
+
+        Returns
+        -------
+        :obj:`ModificationResult`
+            ModificationResult object with the results of the operation.
+        """
+        logger.info(f"Batch update: {subject}")
+        subject.id = self._get_wb_id_of(subject, subject.wdi_proptype)
+        entity = self._local_item_engine(subject.id)
+        for triple in triples:
+            _, predicate, objct = triple.content
+            update_callbacks = self._create_callbacks if triple.isAdded else self._remove_callbacks
+            self._update_entity(entity, predicate, objct, update_callbacks)
+        return self._try_write(entity, entity_type=subject.etype,
+                               property_datatype=subject.wdi_dtype)
 
     def create_triple(self, triple_info: TripleInfo) -> ModificationResult:
         """ Creates the given triple in the wikibase instance.
@@ -54,7 +85,7 @@ class WikibaseAdapter(TripleStoreManager):
         Parameters
         ----------
         triple_info: :obj:`TripleInfo`
-            Instance of the TripleInfo class with the data to be added to the wikibase.
+            Instance of the TripleInfo class with the data to be added to Wikibase.
 
         Returns
         -------
@@ -64,23 +95,10 @@ class WikibaseAdapter(TripleStoreManager):
         logger.info(f"Create triple: {triple_info}")
         subject, predicate, objct = triple_info.content
         subject.id = self._get_wb_id_of(subject, subject.wdi_proptype)
-
-        if self.is_wb_label(predicate):
-            return self._set_label(subject, objct)
-
-        if self.is_wb_description(predicate):
-            return self._set_description(subject, objct)
-
-        if self.is_wb_alias(predicate):
-            return self._set_alias(subject, objct)
-
-        if isinstance(objct, URIElement) or isinstance(objct, AnonymousElement):
-            objct.id = self._get_wb_id_of(objct, objct.wdi_proptype)
-
-        predicate.etype = 'property'
-        predicate.id = self._get_wb_id_of(predicate, objct.wdi_dtype)
-
-        return self._create_statement(subject, predicate, objct)
+        entity = self._local_item_engine(subject.id)
+        self._update_entity(entity, predicate, objct, self._create_callbacks)
+        return self._try_write(entity, entity_type=subject.etype,
+                               property_datatype=subject.wdi_dtype)
 
     def remove_triple(self, triple_info: TripleInfo) -> ModificationResult:
         """ Removes the given triple from the wikibase instance.
@@ -98,41 +116,17 @@ class WikibaseAdapter(TripleStoreManager):
         logger.info(f"Remove triple: {triple_info}")
         subject, predicate, objct = triple_info.content
         subject.id = self._get_wb_id_of(subject, subject.wdi_proptype)
-
-        if self.is_wb_label(predicate):
-            return self._remove_label(subject, objct)
-
-        if self.is_wb_description(predicate):
-            return self._remove_description(subject, objct)
-
-        if self.is_wb_alias(predicate):
-            return self._remove_alias(subject, objct)
-
-        predicate.etype = 'property'
-        predicate.id = self._get_wb_id_of(predicate, objct.wdi_dtype)
-        return self._remove_statement(subject, predicate)
-
-    def _create_statement(self, subject: TripleElement, predicate: TripleElement,
-                          objct: TripleElement) -> ModificationResult:
-        statement = objct.to_wdi_datatype(prop_nr=predicate.id)
-        data = [statement]
-        litem = self._local_item_engine(subject.id, data=data, append_value=[predicate.id])
-        return self._try_write(litem, entity_type=subject.etype,
+        entity = self._local_item_engine(subject.id)
+        self._update_entity(entity, predicate, objct, self._remove_callbacks)
+        return self._try_write(entity, entity_type=subject.etype,
                                property_datatype=subject.wdi_dtype)
 
-    def _remove_statement(self, subject: TripleElement,
-                          predicate: TripleElement) -> ModificationResult:
-        statement_to_remove = wdi_core.WDBaseDataType.delete_statement(predicate.id)
-        data = [statement_to_remove]
-        litem = self._local_item_engine(subject.id, data=data)
-        return self._try_write(litem, entity_type=subject.etype,
-                               property_datatype=subject.wdi_dtype)
-
-    def _add_mappings_to_entity(self, entity, uri: str):
+    def _add_mappings_to_entity(self, entity: wdi_core.WDItemEngine, uri: str):
         same_as = wdi_core.WDUrl(value=uri, prop_nr=self._mappings_prop)
         entity.update([same_as], append_value=[self._mappings_prop])
 
-    def _create_new_wb_item(self, uriref: NonLiteralElement, proptype: str) -> ModificationResult:
+    def _create_new_wb_item(self, uriref: NonLiteralElement,
+                            proptype: str) -> wdi_core.WDItemEngine:
         entity = self._local_item_engine(new_item=True)
         label = try_infer_label_from(uriref)
         if label is None:
@@ -145,6 +139,13 @@ class WikibaseAdapter(TripleStoreManager):
 
         return self._try_write(entity, entity_type=uriref.etype,
                                property_datatype=proptype)
+
+    def _create_statement(self, entity: wdi_core.WDItemEngine, predicate: TripleElement,
+                          objct: TripleElement) -> wdi_core.WDItemEngine:
+        statement = objct.to_wdi_datatype(prop_nr=predicate.id)
+        data = [statement]
+        entity.update(data=data, append_value=[predicate.id])
+        return entity
 
     def _get_or_create_mappings_prop(self):
         mappings_prop_id = None
@@ -182,58 +183,56 @@ class WikibaseAdapter(TripleStoreManager):
         post_uri(uriref.uri, entity_id)
         return entity_id
 
-    def _set_alias(self, subject, objct) -> ModificationResult:
-        lang = get_lang_from_literal(objct)
-        logging.debug("Changing alias @%s of %s", lang, subject)
-        entity = self._local_item_engine(subject.id)
-        entity.set_aliases([objct.content], lang)
-        return self._try_write(entity, entity_type=subject.etype)
-
-    def _set_label(self, subject, objct) -> ModificationResult:
-        lang = get_lang_from_literal(objct)
-        logging.debug("Changing label @%s of %s", lang, subject)
-        entity = self._local_item_engine(subject.id)
-        entity.set_label(objct.content, lang)
-        return self._try_write(entity, entity_type=subject.etype)
-
-    def _set_description(self, subject, objct) -> ModificationResult:
-        lang = get_lang_from_literal(objct)
-        logging.debug("Setting description @%s of %s", lang, subject)
-        entity = self._local_item_engine(subject.id)
-        entity.set_description(objct.content[:MAX_CHARACTERS_DESC], lang)
-        return self._try_write(entity, entity_type=subject.etype)
-
-    def _remove_alias(self, subject, objct) -> ModificationResult:
+    def _remove_alias(self, entity: wdi_core.WDItemEngine, objct: LiteralElement) -> wdi_core.WDItemEngine:
         lang = get_lang_from_literal(objct)
         logging.debug("Removing alias @%s of %s", lang, subject)
-        entity = self._local_item_engine(subject.id)
         curr_aliases = entity.get_aliases(lang)
         try:
             curr_aliases.remove(objct.content)
+            entity.set_aliases(curr_aliases, lang, append=False)
         except ValueError:
             logging.warning("Alias %s@%s does not exist for object %s. Skipping removal...",
                             objct.content, lang, subject.id)
-            err_msg = f"Error removing alias {objct.content}@{lang}."
-            return ModificationResult(successful=False, message=err_msg)
-        entity.set_aliases(curr_aliases, lang, append=False)
-        return self._try_write(entity, entity_type=subject.etype)
+        return entity
 
-
-    def _remove_label(self, subject, objct) -> ModificationResult:
-        lang = get_lang_from_literal(objct)
-        logging.debug("Removing label @%s of %s", lang, subject)
-        entity = self._local_item_engine(subject.id)
-        entity.set_label("", lang)
-        return self._try_write(entity, entity_type=subject.etype)
-
-    def _remove_description(self, subject, objct) -> ModificationResult:
+    def _remove_description(self, entity: wdi_core.WDItemEngine, objct: LiteralElement) -> wdi_core.WDItemEngine:
         lang = get_lang_from_literal(objct)
         logging.debug("Removing description @%s of %s", lang, subject)
-        entity = self._local_item_engine(subject.id)
         entity.set_description("", lang)
-        return self._try_write(entity, entity_type=subject.etype)
+        return entity
 
-    def _try_write(self, entity, **kwargs) -> ModificationResult:
+    def _remove_label(self, entity: wdi_core.WDItemEngine, objct: LiteralElement) -> wdi_core.WDItemEngine:
+        lang = get_lang_from_literal(objct)
+        logging.debug("Removing label @%s of %s", lang, subject)
+        entity.set_label("", lang)
+        return entity
+
+    def _remove_statement(self, entity: wdi_core.WDItemEngine,
+                          predicate: TripleElement, _) -> wdi_core.WDItemEngine:
+        statement_to_remove = wdi_core.WDBaseDataType.delete_statement(predicate.id)
+        data = [statement_to_remove]
+        entity.update(data=data)
+        return entity
+
+    def _set_alias(self, entity: wdi_core.WDItemEngine, objct: LiteralElement) -> wdi_core.WDItemEngine:
+        lang = get_lang_from_literal(objct)
+        logging.debug("Changing alias @%s of %s", lang, subject)
+        entity.set_aliases([objct.content], lang)
+        return entity
+
+    def _set_description(self, entity: wdi_core.WDItemEngine, objct: LiteralElement) -> wdi_core.WDItemEngine:
+        lang = get_lang_from_literal(objct)
+        logging.debug("Setting description @%s of %s", lang, subject)
+        entity.set_description(objct.content[:MAX_CHARACTERS_DESC], lang)
+        return entity
+
+    def _set_label(self, entity: wdi_core.WDItemEngine, objct: LiteralElement) -> wdi_core.WDItemEngine:
+        lang = get_lang_from_literal(objct)
+        logging.debug("Changing label @%s of %s", lang, subject)
+        entity.set_label(objct.content, lang)
+        return entity
+
+    def _try_write(self, entity: wdi_core.WDItemEngine, **kwargs) -> ModificationResult:
         try:
             eid = entity.write(self._local_login, **kwargs)
             return ModificationResult(successful=True, res=eid)
@@ -244,6 +243,24 @@ class WikibaseAdapter(TripleStoreManager):
             if err_code == ERR_CODE_LANGUAGE:
                 logger.warning("Language was not recognized. Skipping it...")
             return ModificationResult(successful=False, message=msg)
+
+    def _update_entity(self, entity: wdi_core.WDItemEngine, predicate: TripleElement,
+                       objct: TripleElement, update_callbacks) -> wdi_core.WDItemEngine:
+        if self.is_wb_label(predicate):
+            return update_callbacks['onLabel'](entity, objct)
+
+        if self.is_wb_description(predicate):
+            return update_callbacks['onDesc'](entity, objct)
+
+        if self.is_wb_alias(predicate):
+            return update_callbacks['onAlias'](entity, objct)
+
+        if isinstance(objct, URIElement) or isinstance(objct, AnonymousElement):
+            objct.id = self._get_wb_id_of(objct, objct.wdi_proptype)
+
+        predicate.etype = 'property'
+        predicate.id = self._get_wb_id_of(predicate, objct.wdi_dtype)
+        return update_callbacks['onStatement'](entity, predicate, objct)
 
     @classmethod
     def is_wb_alias(cls, predicate: URIElement) -> bool:
@@ -265,19 +282,24 @@ def get_uri_for(label):
     uri_factory = URIFactory()
     return uri_factory.get_uri(label)
 
+
 def get_lang_from_literal(objct):
     if not hasattr(objct, 'lang') or objct.lang is None:
-        logging.warning("Literal %s has no language. Defaulting to '%s'", objct, DEFAULT_LANG)
+        logging.warning("Literal %s has no language. Defaulting to '%s'",
+                        objct, DEFAULT_LANG)
         return DEFAULT_LANG
     return objct.lang
 
+
 def is_asio_uri(uriref: NonLiteralElement) -> bool:
     return '/hercules/asio' in uriref.uri
+
 
 def post_uri(label, uri):
     logging.debug("Calling POST of URIFactory: %s - %s", label, uri)
     uri_factory = URIFactory()
     return uri_factory.post_uri(label, uri)
+
 
 def try_infer_label_from(uriref: NonLiteralElement):
     if '#' in uriref:

--- a/hercules_sync/triplestore/wikibase_adapter.py
+++ b/hercules_sync/triplestore/wikibase_adapter.py
@@ -146,7 +146,7 @@ class WikibaseAdapter(TripleStoreManager):
 
     def _get_or_create_mappings_prop(self):
         mappings_prop_id = None
-        query_res = json.loads(requests.get(f"{self.api_url}?action=wbsearchentities" + \
+        query_res = json.loads(requests.get(f"{self.api_url}?action=wbsearchentities" +
             f"&search={MAPPINGS_PROP_LABEL}&format=json&language=en&type=property").text)
         if 'search' in query_res and len(query_res['search']) > 0:
             for search_result in query_res['search']:
@@ -185,7 +185,6 @@ class WikibaseAdapter(TripleStoreManager):
                                       onLabel=self._set_label, onStatement=self._create_statement)
         self._remove_callbacks = dict(onAlias=self._remove_alias, onDesc=self._remove_description,
                                       onLabel=self._remove_label, onStatement=self._remove_statement)
-
 
     def _remove_alias(self, entity: wdi_core.WDItemEngine, objct: LiteralElement) -> wdi_core.WDItemEngine:
         lang = get_lang_from_literal(objct)

--- a/tests/test_algorithms.py
+++ b/tests/test_algorithms.py
@@ -1,10 +1,7 @@
-import os
-
 import pytest
 
 from rdflib.namespace import XSD
 
-from hercules_sync.git import GitFile
 from hercules_sync.synchronization import AdditionOperation, RemovalOperation, \
                                           GraphDiffSyncAlgorithm, NaiveSyncAlgorithm, \
                                           RDFSyncAlgorithm
@@ -20,9 +17,11 @@ TARGET_FILE = 'target.ttl'
 ASIO_PREFIX = 'http://www.asio.es/asioontologies/asio#'
 EX_PREFIX = 'http://www.semanticweb.org/spitxa/ontologies/2020/1/asio-human-resource#'
 
+
 @pytest.fixture(scope='module')
 def input():
     return load_gitfile_from(SOURCE_FILE, TARGET_FILE)
+
 
 class TestNaiveSyncAlgorithm:
     @pytest.fixture(scope='class')
@@ -34,6 +33,7 @@ class TestNaiveSyncAlgorithm:
             algorithm.do_algorithm(input)
         assert 'has not been implemented yet' in str(excpt.value)
 
+
 class TestRDFSyncAlgorithm:
     @pytest.fixture(scope='class')
     def algorithm(self):
@@ -43,6 +43,7 @@ class TestRDFSyncAlgorithm:
         with pytest.raises(NotImplementedError) as excpt:
             algorithm.do_algorithm(input)
         assert 'has not been implemented yet' in str(excpt.value)
+
 
 class TestGraphSyncAlgorithm:
     @pytest.fixture(scope='class')
@@ -111,6 +112,16 @@ class TestGraphSyncAlgorithm:
 
         assert len(operations) == len(expected)
         _assert_lists_have_same_elements(expected, operations)
+
+        for op in operations:
+            triple = op._triple_info
+            if isinstance(op, AdditionOperation):
+                assert triple.isAdded
+            elif isinstance(op, RemovalOperation):
+                assert not triple.isAdded
+            else:
+                assert False, "Invalid operation type detected"
+
 
 def _assert_lists_have_same_elements(expected, result):
     for el in result:

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -3,6 +3,7 @@ from unittest import mock
 import pytest
 
 from hercules_sync.synchronization import AdditionOperation, BatchOperation, RemovalOperation
+from hercules_sync.synchronization.operations import optimize_ops
 from hercules_sync.triplestore import LiteralElement, TripleInfo, URIElement
 from hercules_sync.util.uri_constants import RDFS_LABEL
 
@@ -53,6 +54,16 @@ def test_removal(mock_triplestore, triple):
     removal_op = RemovalOperation(*triple)
     removal_op.execute(mock_triplestore)
     mock_triplestore.remove_triple.assert_called_once_with(TripleInfo(*triple))
+
+
+def test_optimize_ops(triple):
+    triple_b = (URIElement('http://example.org/onto#Singer'), URIElement(RDFS_LABEL),
+                LiteralElement('Cantante', 'es'))
+    original_ops = [AdditionOperation(*triple), AdditionOperation(*triple_b), RemovalOperation(*triple)]
+    result_ops = optimize_ops(original_ops)
+    assert len(result_ops) == 2
+    for op in result_ops:
+        assert isinstance(op, BatchOperation)
 
 
 def test_two_operations_with_same_triple_are_distinct(triple):

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -2,13 +2,15 @@ from unittest import mock
 
 import pytest
 
-from hercules_sync.synchronization import AdditionOperation, RemovalOperation
+from hercules_sync.synchronization import AdditionOperation, BatchOperation, RemovalOperation
 from hercules_sync.triplestore import LiteralElement, TripleInfo, URIElement
 from hercules_sync.util.uri_constants import RDFS_LABEL
+
 
 @pytest.fixture
 def mock_triplestore():
     return mock.MagicMock()
+
 
 @pytest.fixture
 def triple():
@@ -17,9 +19,11 @@ def triple():
     objct = LiteralElement('Persona', 'es')
     return (subject, predicate, objct)
 
+
 def test_init(triple):
     addition_op = AdditionOperation(*triple)
     assert addition_op._triple_info == TripleInfo(*triple)
+
 
 def test_str(triple):
     addition_op = AdditionOperation(*triple)
@@ -28,15 +32,28 @@ def test_str(triple):
     removal_op = RemovalOperation(*triple)
     assert str(removal_op) == f"RemovalOperation: {triple[0]} - {triple[1]} - {triple[2]}"
 
+    batch_op = BatchOperation(triple[0], [triple, triple])
+    assert str(batch_op) == f"BatchOperation: {triple[0]}\n{triple}\n{triple}"
+
+
 def test_addition(mock_triplestore, triple):
     addition_op = AdditionOperation(*triple)
     addition_op.execute(mock_triplestore)
     mock_triplestore.create_triple.assert_called_once_with(TripleInfo(*triple))
 
+
+def test_batch(mock_triplestore, triple):
+    triples = [triple] * 3
+    batch_op = BatchOperation(triple[0], triples)
+    batch_op.execute(mock_triplestore)
+    mock_triplestore.batch_update.assert_called_once_with(triple[0], triples)
+
+
 def test_removal(mock_triplestore, triple):
     removal_op = RemovalOperation(*triple)
     removal_op.execute(mock_triplestore)
     mock_triplestore.remove_triple.assert_called_once_with(TripleInfo(*triple))
+
 
 def test_two_operations_with_same_triple_are_distinct(triple):
     add = AdditionOperation(*triple)

--- a/tests/test_triple_info.py
+++ b/tests/test_triple_info.py
@@ -8,11 +8,13 @@ from hercules_sync.triplestore import AnonymousElement, LiteralElement, TripleEl
 from hercules_sync.util.error import InvalidArgumentError
 from hercules_sync.util.uri_constants import ASIO_BASE, GEO_BASE
 
+
 @pytest.fixture()
 def rdflib_triple():
     return (URIRef('http://example.org/onto#Human'),
             URIRef('http://example.org/onto#altName'),
             Literal('Person'))
+
 
 @pytest.fixture
 def prop_uri():
@@ -20,26 +22,32 @@ def prop_uri():
     etype = 'property'
     return URIElement(uri, etype)
 
+
 @pytest.fixture
 def item_uri():
     uri = 'http://example.org/onto#Person'
     return URIElement(uri)
 
+
 @pytest.fixture
 def string_literal():
     return LiteralElement('test')
+
 
 @pytest.fixture
 def anonymous_element():
     return AnonymousElement('cb0')
 
+
 @pytest.fixture
 def monolingual_literal():
     return LiteralElement('목소리', lang='ko')
 
+
 @pytest.fixture
 def datatype_literal():
     return LiteralElement("12", datatype=XSD.integer)
+
 
 def test_anonymous_node_init(anonymous_element):
     assert anonymous_element.uid == 'cb0'
@@ -47,21 +55,35 @@ def test_anonymous_node_init(anonymous_element):
     assert anonymous_element.prefix == ASIO_BASE
     assert anonymous_element.id == None
 
+
 def test_anonymous_node_uri(anonymous_element):
     assert anonymous_element.uri == f'{ASIO_BASE}/genid/{anonymous_element.uid}'
+
 
 def test_uri_str(anonymous_element):
     expected = f"AnonymousElement: {anonymous_element.uri}"
     assert expected == str(item_uri)
 
+
 def test_uri_wdi_class(anonymous_element):
     assert anonymous_element.wdi_class == WDItemID
+
 
 def test_uri_wdi_dtype(anonymous_element):
     assert anonymous_element.wdi_dtype == WDItemID.DTYPE
 
+
 def test_uri_wdi_proptype(anonymous_element):
     assert anonymous_element.wdi_proptype is None
+
+
+def test_is_added(rdflib_triple):
+    triple = TripleInfo.from_rdflib(rdflib_triple)
+    assert triple.isAdded
+
+    triple_to_delete = TripleInfo.from_rdflib(rdflib_triple, isAdded=False)
+    assert not triple_to_delete.isAdded
+
 
 def test_from_rdflib(rdflib_triple):
     triple = TripleInfo.from_rdflib(rdflib_triple).content
@@ -82,15 +104,18 @@ def test_from_rdflib(rdflib_triple):
     assert bnode.uid == 'cb0'
     assert bnode == f'{ASIO_BASE}/genid/cb0'
 
+
 def test_is_blank(string_literal, item_uri, anonymous_element):
     assert not string_literal.is_blank()
     assert not item_uri.is_blank()
     assert anonymous_element.is_blank()
 
+
 def test_is_literal(string_literal, item_uri, anonymous_element):
     assert string_literal.is_literal()
     assert not item_uri.is_literal()
     assert not anonymous_element.is_literal()
+
 
 def test_is_uri(string_literal, item_uri, anonymous_element):
     assert not string_literal.is_uri()
@@ -118,20 +143,24 @@ def test_literal_init():
         LiteralElement("12", datatype=XSD.integer, lang='es')
     assert 'Both datatype and language' in str(excpt.value)
 
+
 def test_literal_str(string_literal, monolingual_literal, datatype_literal):
     assert str(string_literal) == 'LiteralElement: test'
     assert str(monolingual_literal) == 'LiteralElement: 목소리 - Language: ko'
     assert str(datatype_literal) == f'LiteralElement: 12 - DataType: {XSD.integer}'
+
 
 def test_literal_wdi_class(string_literal, monolingual_literal, datatype_literal):
     assert string_literal.wdi_class == WDString
     assert monolingual_literal.wdi_class == WDMonolingualText
     assert datatype_literal.wdi_class == WDQuantity
 
+
 def test_literal_wdi_dtype(string_literal, monolingual_literal, datatype_literal):
     assert string_literal.wdi_dtype == WDString.DTYPE
     assert monolingual_literal.wdi_dtype == WDMonolingualText.DTYPE
     assert datatype_literal.wdi_dtype == WDQuantity.DTYPE
+
 
 def test_literal_wdi_datatype(string_literal, monolingual_literal, datatype_literal):
     assert monolingual_literal.to_wdi_datatype(prop_nr=1) == monolingual_literal.wdi_class(value=monolingual_literal.content,
@@ -139,21 +168,25 @@ def test_literal_wdi_datatype(string_literal, monolingual_literal, datatype_lite
     unkown_datatype = LiteralElement("12", datatype="invented")
     assert unkown_datatype.to_wdi_datatype(prop_nr=1) == WDString(value=unkown_datatype.content, prop_nr=1)
 
+
 def test_literal_equals(string_literal, monolingual_literal, datatype_literal):
     assert 'test' != string_literal
     assert LiteralElement('test') == string_literal
     assert LiteralElement('목소리', lang='ko') == monolingual_literal
     assert LiteralElement('12', datatype=XSD.integer) == datatype_literal
 
+
 def test_tripleinfo_str(rdflib_triple):
     triple = TripleInfo.from_rdflib(rdflib_triple)
     assert str(triple) == f"{triple.subject} - {triple.predicate} - {triple.object}"
+
 
 def test_uri_init(prop_uri):
     assert prop_uri.uri == 'http://example.org/onto#livesIn'
     assert prop_uri.etype == 'property'
     assert prop_uri.id is None
     assert prop_uri.proptype is None
+
 
 def test_uri_etype():
     element = URIElement('')
@@ -166,17 +199,21 @@ def test_uri_etype():
         element.etype = 'invented'
     assert 'Invalid etype' in str(excpt.value)
 
+
 def test_uri_str(item_uri):
     expected = f"URIElement: {item_uri.uri} - Type: item"
     assert expected == str(item_uri)
+
 
 def test_uri_wdi_class(prop_uri, item_uri):
     assert prop_uri.wdi_class == WDProperty
     assert item_uri.wdi_class == WDItemID
 
+
 def test_uri_wdi_dtype(prop_uri, item_uri):
     assert prop_uri.wdi_dtype == WDProperty.DTYPE
     assert item_uri.wdi_dtype == WDItemID.DTYPE
+
 
 def test_uri_wdi_proptype(prop_uri, item_uri):
     assert prop_uri.wdi_proptype is None


### PR DESCRIPTION
Closes #41. 

We have added a new way to perform operations more efficiently with Wikibase. The following features were added:
* New function to optimise basic operations into batch operations.
    * Batch operations are considerably more efficient when there are many updates to execute for the same set of subjects.
   * All of these operations are executed in a single transaction, minimising the performance overhead of communicating with Wikibase.
* Small refactor of the WikibaseAdapter class to minimise the calls to the wdi_core.WDItemEngine `write` method. We are making as many calls as possible to the `update` method instead, in order to reduce the writing operations to Wikibase and improve the overall performance.

This will unlock the start of #60, where we can illustrate with a visual approach the improvements that have been made.